### PR TITLE
Model固有のScoreを返すべきタイミングで絵文字を返しており、他のルールを上書きすることがあった

### DIFF
--- a/twemoji.rb
+++ b/twemoji.rb
@@ -75,9 +75,11 @@ end
 
 Plugin.create(:twemoji) do
   filter_score_filter do |model, note, yielder|
-    score = Plugin::Twemoji.parse(note.description)
-    if score.size > 1 || score.size == 1 && !score[0].is_a?(Plugin::Score::TextNote)
-      yielder << score
+    if model != note
+      score = Plugin::Twemoji.parse(note.description)
+      if score.size > 1 || score.size == 1 && !score[0].is_a?(Plugin::Score::TextNote)
+        yielder << score
+      end
     end
     [model, note, yielder]
   end


### PR DESCRIPTION
score_filterの引数modelとnoteに同じものが渡される、Model全体にかかる固有のScoreルールを問い合わせている段階でも反応してしまっていて、ロード順によってはTwitter Entityが無視されてしまう問題がありました。